### PR TITLE
Feature - squarer pixels

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -13,8 +13,16 @@ class ModelLoader(TypedDict):
 
 def pixelate(image: np.ndarray, blocks: int = 3) -> np.ndarray:
     (h, w) = image.shape[:2]
-    x_steps = np.linspace(0, w, blocks + 1, dtype="int")
-    y_steps = np.linspace(0, h, blocks + 1, dtype="int")
+    
+    if h > w:
+        blocks_h = blocks
+        blocks_w = int(blocks * (w/h))
+    else:
+        blocks_h = int(blocks * (h/w))
+        blocks_w = blocks
+    
+    x_steps = np.linspace(0, w, blocks_w + 1, dtype="int")
+    y_steps = np.linspace(0, h, blocks_h + 1, dtype="int")
 
     for i in range(1, len(y_steps)):
         for j in range(1, len(x_steps)):


### PR DESCRIPTION
This PR adjusts pixel block scaling within `utils.pixelate()`.

By changing the step distance per-axis, it brings the pixelated blocks closer to a square aspect ratio, instead of inheriting the detections aspect ratio.

E: The longest axis gets the specified block count, and the shorter axis gets fewer. Also apologies for basing this on the wrong commit, it includes my other PR #6